### PR TITLE
Share single display on X11

### DIFF
--- a/ext/say_x11.h
+++ b/ext/say_x11.h
@@ -40,4 +40,5 @@ typedef struct say_x11_context {
   Window   win;
 
   bool should_free_window;
+  bool should_close_display;
 } say_x11_context;

--- a/ext/say_x11_context.h
+++ b/ext/say_x11_context.h
@@ -61,7 +61,13 @@ say_imp_context say_imp_context_create_shared(say_imp_context shared) {
 
   context->should_free_window = true;
 
-  context->dis = XOpenDisplay(NULL);
+  if (shared != NULL) {
+    context->should_close_display = false;
+    context->dis = shared->dis;
+  } else {
+    context->should_close_display = true;
+    context->dis = XOpenDisplay(NULL);
+  }
 
   int screen = DefaultScreen(context->dis);
 
@@ -130,14 +136,13 @@ void say_imp_context_free(say_imp_context context) {
       glXMakeCurrent(context->dis, None, NULL);
   }
 
-  if (context->should_free_window) {
-    if (context->win) {
-      XDestroyWindow(context->dis, context->win);
-      XFlush(context->dis);
-    }
-
-    XCloseDisplay(context->dis);
+  if (context->should_free_window && context->win) {
+    XDestroyWindow(context->dis, context->win);
+    XFlush(context->dis);
   }
+
+  if (context->should_close_display)
+    XCloseDisplay(context->dis);
 }
 
 void say_imp_context_make_current(say_imp_context context) {

--- a/ext/say_x11_window.h
+++ b/ext/say_x11_window.h
@@ -147,7 +147,9 @@ bool say_imp_window_open(say_imp_window win, const char *title,
   if (win->dis)
     say_imp_window_close(win);
 
-  win->dis = XOpenDisplay(NULL);
+  say_context *context = say_context_create();
+  win->dis = context->context->dis;
+  say_context_free(context);
 
   if (!win->dis) {
     say_error_set("could not open X display");
@@ -348,10 +350,8 @@ void say_imp_window_close(say_imp_window win) {
     win->win = None;
   }
 
-  if (win->dis) {
-    XCloseDisplay(win->dis);
+  if (win->dis)
     win->dis = NULL;
-  }
 }
 
 void say_imp_window_show_cursor(say_imp_window win) {


### PR DESCRIPTION
Hi,

This pull request fixes a problem with ray when used on X11 with Intel GPU. Without this patch, the tests abort halfway with the error 'intel_do_flush_locked failed: No such file or directory'.

Based on [this discussion](http://gstreamer-devel.966125.n4.nabble.com/GL-plugin-SDL-example-td4669260.html) I changed the code to ensure all GL contexts use the same X11 display.

The changes could be improved by making the initial context more readily available to the rest of the code.
