### PR TITLE
Makes the gem installation work on linux

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,8 +3,15 @@ require 'mkmf'
 $CFLAGS  << " -Wextra -Wall -Wno-unused-parameter -std=gnu99 "
 
 unless RUBY_PLATFORM =~ /mingw/
-  $CFLAGS  << " " << `freetype-config --cflags`.chomp
-  $LDFLAGS << " " << `freetype-config --libs`.chomp
+  if RUBY_PLATFORM =~ /linux/
+    $CFLAGS  << " " << `pkg-config --cflags`.chomp
+    $CFLAGS  << " " << "-I/usr/include/freetype2"
+    $LDFLAGS << " " << `pkg-config --libs`.chomp
+    $LDFLAGS << " " << "-L/usr/local/lib -lfreetype"
+  else
+    $CFLAGS  << " " << `freetype-config --cflags`.chomp
+    $LDFLAGS << " " << `freetype-config --libs`.chomp
+  end
 end
 
 if RUBY_PLATFORM =~ /darwin/


### PR DESCRIPTION
A tiny update of extconf to be able to install the gem on linux
Tested on (Ubuntu 19.10 with `ruby 2.7.0`)

Command to install prerequires packages
```shell
sudo apt install glew-utils libglew-dev libsndfile1-dev libopenal-dev libfreetype6-dev libxrandr-dev
```
Thank 